### PR TITLE
Prevents plugin from breaking

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,6 +47,7 @@ const newHeaderInfo = (document: TextDocument, headerInfo?: HeaderInfo) => {
     // This will be overwritten if headerInfo is not null
     {
       createdAt: moment(),
+      author: `${user} <${mail}>`,
       createdBy: user
     },
     headerInfo,


### PR DESCRIPTION
This change allows the author to be set when generating a new header, but doesn't update it on every save.